### PR TITLE
DRY up page navigation + onhashchange + IE11 compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,66 +134,53 @@
     }
 
 
-
     $('#home').click(function() {
-        $('#page-content-wrapper').load('pages/home.html');
-        $(window).scrollTop(0);
+        goToPage('home');
         toggleSideBarOnMobile();
     });
 
     $('#tutoring').click(function() {
-        $('#page-content-wrapper').load('pages/tutoring.html');
-        $(window).scrollTop(0);
+        goToPage('tutoring');
         toggleSideBarOnMobile();
     });
 
     $('#events').click(function() {
-        $('#page-content-wrapper').load('pages/events.html');
-        $(window).scrollTop(0);
+        goToPage('events');
         toggleSideBarOnMobile();
     });
 
     $('#executives').click(function() {
-        $('#page-content-wrapper').load('pages/executives.html');
-        $(window).scrollTop(0);
+        goToPage('executives');
         toggleSideBarOnMobile();
     });
 
     $('#resources').click(function() {
-        $('#page-content-wrapper').load('pages/resources.html');
-        $(window).scrollTop(0);
+        goToPage('resources');
         toggleSideBarOnMobile();
     });
 
     $('#scholarships').click(function() {
-        $('#page-content-wrapper').load('pages/scholarships.html');
-        $(window).scrollTop(0);
+        goToPage('scholarships');
         toggleSideBarOnMobile();
     });
 
     $('#contact-us').click(function() {
-        $('#page-content-wrapper').load('pages/contact-us.html');
-        $(window).scrollTop(0);
+        goToPage('contact-us');
         toggleSideBarOnMobile();
     });
 
     $('#sign-up').click(function() {
-        $('#page-content-wrapper').load('pages/sign-up.html');
-        $(window).scrollTop(0);
+        goToPage('sign-up');
         toggleSideBarOnMobile();
-
     });
 
     $('#contact-us-on').click(function() {
-        $('#page-content-wrapper').load('pages/contact-us-on.html');
-        $(window).scrollTop(0);
+        goToPage('contact-us-on');
         toggleSideBarOnMobile();
-
     });
 
     $('#blog').click(function() {
-        $('#page-content-wrapper').load('pages/blog.html');
-        $(window).scrollTop(0);
+        goToPage('blog');
         toggleSideBarOnMobile();
 
     });

--- a/index.html
+++ b/index.html
@@ -96,9 +96,6 @@
     // Links that go to a subpage.
     var pageLinks = $('.sidebar-nav a[id]');
 
-    var hash = window.location.hash;
-    console.assert(hash.length === 0 || hash[0] === '#');
-    var requestedPage = hash.slice('1');
 
     // Get a array of all of the valid pages.
     // Valid pages are marked by an #id in the sidebar-nav.
@@ -106,13 +103,7 @@
         return element.id;
     }).toArray();
 
-
-    // this if else allows the URL's to specify what tab you want to see
-    if (pages.includes(requestedPage)) {
-        goToPage(requestedPage);
-    } else {
-        goToPage('home');
-    }
+    navigateToPageBasedOnHash(window.location.hash);
 
     // Whenever you click a link in the sidebar, it should navigate to
     // the page as specified in the #id
@@ -125,6 +116,18 @@
     toggleSideBarOnMobile = () => {
         if ($(window).width() < 700){
             $("#wrapper").toggleClass("toggled");
+        }
+    }
+
+    function navigateToPageBasedOnHash(hash) {
+        console.assert(hash.length === 0 || hash[0] === '#');
+        var requestedPage = hash.slice('1');
+
+        // this if else allows the URL's to specify what tab you want to see
+        if (pages.includes(requestedPage)) {
+            goToPage(requestedPage);
+        } else {
+            goToPage('home');
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -96,46 +96,41 @@
 
     var hash = window.location.hash;
 
+    function goToPage(name) {
+        $('#page-content-wrapper').load('pages/' + name + '.html');
+        $(window).scrollTop(0);
+    }
+
     // this if else allows the URL's to specify what tab you want to see
     if(hash == "#tutoring") {
-        $('#page-content-wrapper').load('pages/tutoring.html');
-        $(window).scrollTop(0);
+        goToPage('tutoring');
     }
     else if(hash == "#events") {
-    	$('#page-content-wrapper').load('pages/events.html');
-        $(window).scrollTop(0);
+    	goToPage('events');
     }
     else if(hash == "#executives") {
-        $('#page-content-wrapper').load('pages/executives.html');
-        $(window).scrollTop(0);
+        goToPage('executives');
     }
     else if(hash == "#resources") {
-    	$('#page-content-wrapper').load('pages/resources.html');
-        $(window).scrollTop(0);
+    	goToPage('resources');
     }
     else if(hash == "#scholarships") {
-        $('#page-content-wrapper').load('pages/scholarships.html');
-        $(window).scrollTop(0);
+        goToPage('scholarships');
     }
     else if(hash == "#contact-us") {
-    	$('#page-content-wrapper').load('pages/contact-us.html');
-        $(window).scrollTop(0);
+    	goToPage('contact-us');
     }
     else if(hash == "#sign-up") {
-    	$('#page-content-wrapper').load('pages/sign-up.html');
-        $(window).scrollTop(0);
+    	goToPage('sign-up');
     }
     else if(hash == "#contact-us-on") {
-    	$('#page-content-wrapper').load('pages/contact-us-on.html');
-        $(window).scrollTop(0);
+    	goToPage('contact-us-on');
     }
     else if(hash == "#blog") {
-        $('#page-content-wrapper').load('pages/blog.html');
-        $(window).scrollTop(0);
+        goToPage('blog');
     }
     else {
-    	$('#page-content-wrapper').load('pages/home.html');
-        $(window).scrollTop(0);
+    	goToPage('home');
     }
 
 

--- a/index.html
+++ b/index.html
@@ -80,6 +80,8 @@
 
     <script>
 
+    // Open the sidebar on wide enough screens.
+    // TODO: use a media query for this?
     $(document).ready(function(){
         if ($(window).width() > 700){
             $("#wrapper").toggleClass("toggled");
@@ -93,9 +95,8 @@
 
     $('#footer').load('pages/footer.html');
 
-    // Links that go to a subpage.
+    // Collect all of the links that go to pages/*.html.
     var pageLinks = $('.sidebar-nav a[id]');
-
 
     // Get a array of all of the valid pages.
     // Valid pages are marked by an #id in the sidebar-nav.
@@ -106,7 +107,7 @@
     navigateToPageBasedOnHash(window.location.hash);
 
     // Whenever the URI's #fragment (a.k.a., hash) changes, navigate to a new page.
-    // NB: the sidebar links will chance the hash appropriately.
+    // NB: the sidebar links will change the hash appropriately.
     if ('onhashchange' in window) {
         window.onhashchange = (_event) => {
             navigateToPageBasedOnHash(window.location.hash);

--- a/index.html
+++ b/index.html
@@ -119,57 +119,13 @@
         goToPage('home');
     }
 
-
-    $('#home').click(function() {
-        goToPage('home');
+    // Whenever you click a link in the sidebar, it should navigate to
+    // the page as specified in the #id
+    pageLinks.click(function() {
+        goToPage(this.id);
         toggleSideBarOnMobile();
     });
 
-    $('#tutoring').click(function() {
-        goToPage('tutoring');
-        toggleSideBarOnMobile();
-    });
-
-    $('#events').click(function() {
-        goToPage('events');
-        toggleSideBarOnMobile();
-    });
-
-    $('#executives').click(function() {
-        goToPage('executives');
-        toggleSideBarOnMobile();
-    });
-
-    $('#resources').click(function() {
-        goToPage('resources');
-        toggleSideBarOnMobile();
-    });
-
-    $('#scholarships').click(function() {
-        goToPage('scholarships');
-        toggleSideBarOnMobile();
-    });
-
-    $('#contact-us').click(function() {
-        goToPage('contact-us');
-        toggleSideBarOnMobile();
-    });
-
-    $('#sign-up').click(function() {
-        goToPage('sign-up');
-        toggleSideBarOnMobile();
-    });
-
-    $('#contact-us-on').click(function() {
-        goToPage('contact-us-on');
-        toggleSideBarOnMobile();
-    });
-
-    $('#blog').click(function() {
-        goToPage('blog');
-        toggleSideBarOnMobile();
-
-    });
 
     toggleSideBarOnMobile = () => {
         if ($(window).width() < 700){

--- a/index.html
+++ b/index.html
@@ -80,6 +80,8 @@
 
     <script>
 
+    installPolyfills();
+
     // Open the sidebar on wide enough screens.
     // TODO: use a media query for this?
     $(document).ready(function(){
@@ -109,22 +111,21 @@
     // Whenever the URI's #fragment (a.k.a., hash) changes, navigate to a new page.
     // NB: the sidebar links will change the hash appropriately.
     if ('onhashchange' in window) {
-        window.onhashchange = (_event) => {
+        window.onhashchange = function (_event) {
             navigateToPageBasedOnHash();
             // You clicked a link in the sidebar, so the sidebar should close.
             toggleSideBarOnMobile();
         }
     }
 
-    toggleSideBarOnMobile = () => {
+    function toggleSideBarOnMobile() {
         if ($(window).width() < 700){
             $("#wrapper").toggleClass("toggled");
         }
     }
 
     function navigateToPageBasedOnHash() {
-        let hash = window.location.hash;
-        console.assert(hash.length === 0 || hash[0] === '#');
+        var hash = window.location.hash;
         var requestedPage = hash.slice('1');
 
         // this if else allows the URL's to specify what tab you want to see
@@ -136,10 +137,57 @@
     }
 
     // Navigates to the given page name.
-    // The name must coorespond to a file in pages/*.html. 
+    // The name must coorespond to a file in pages/*.html.
     function goToPage(name) {
         $('#page-content-wrapper').load('pages/' + name + '.html');
         $(window).scrollTop(0);
+    }
+
+    // IE11 doesn't have Array#includes(), so add it here.
+    function installPolyfills() {
+        if ('includes' in Array.prototype) {
+            return;
+        }
+
+        Object.defineProperty(Array.prototype, 'includes', {
+            // Make sure the property is NON-ENUMERABLE, or else it will
+            // appear in for (var x in array) loops (because JavaScript)
+            enumerable: false,
+            value: includesPolyfill,
+        });
+
+        // Implemented (roughly) according to the standard:
+        // https://www.ecma-international.org/ecma-262/7.0/#sec-array.prototype.includes
+        function includesPolyfill(searchElement, fromIndex) {
+            // The ECMAScript standard chose bad variable names;
+            // I'm just being consistent :/
+            var k;
+            var len;
+            var n;
+
+            len = this.length;
+            if (len === 0) {
+                return false;
+            }
+
+            // ~~+ is a concise way to coerce things into integers.
+            n = ~~+fromIndex || 0;
+            if (n >= 0) {
+                k = n;
+            } else {
+                k = len + n;
+                if (k < 0) {
+                    k = 0;
+                }
+            }
+
+            for (/* 👆👀 */; k < len; k++) {
+                if (this[k] === searchElement) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
     </script>
 

--- a/index.html
+++ b/index.html
@@ -105,13 +105,15 @@
 
     navigateToPageBasedOnHash(window.location.hash);
 
-    // Whenever you click a link in the sidebar, it should navigate to
-    // the page as specified in the #id
-    pageLinks.click(function() {
-        goToPage(this.id);
-        toggleSideBarOnMobile();
-    });
-
+    // Whenever the URI's #fragment (a.k.a., hash) changes, navigate to a new page.
+    // NB: the sidebar links will chance the hash appropriately.
+    if ('onhashchange' in window) {
+        window.onhashchange = (_event) => {
+            navigateToPageBasedOnHash(window.location.hash);
+            // You clicked a link in the sidebar, so the sidebar should close.
+            toggleSideBarOnMobile();
+        }
+    }
 
     toggleSideBarOnMobile = () => {
         if ($(window).width() < 700){

--- a/index.html
+++ b/index.html
@@ -80,8 +80,6 @@
 
     <script>
 
-    installPolyfills();
-
     // Open the sidebar on wide enough screens.
     // TODO: use a media query for this?
     $(document).ready(function(){
@@ -127,7 +125,7 @@
         var requestedPage = hash.slice('1');
 
         // this if else allows the URL's to specify what tab you want to see
-        if (pages.includes(requestedPage)) {
+        if (includes(pages, requestedPage)) {
             goToPage(requestedPage);
         } else {
             goToPage('home');
@@ -141,51 +139,15 @@
         $(window).scrollTop(0);
     }
 
-    // IE11 doesn't have Array#includes(), so add it here.
-    function installPolyfills() {
-        if ('includes' in Array.prototype) {
-            return;
+    // Same as Array.prototype.includes(), but defined here for browsers that
+    // don't support it (*cough* IE11 *cough cough*)
+    function includes(array, searchItem) {
+        for (var i = 0; i < array.length; i++) {
+            if (array[i] === searchItem) {
+                return true;
+            }
         }
-
-        Object.defineProperty(Array.prototype, 'includes', {
-            // Make sure the property is NON-ENUMERABLE, or else it will
-            // appear in for (var x in array) loops (because JavaScript)
-            enumerable: false,
-            value: includesPolyfill,
-        });
-
-        // Implemented (roughly) according to the standard:
-        // https://www.ecma-international.org/ecma-262/7.0/#sec-array.prototype.includes
-        function includesPolyfill(searchElement, fromIndex) {
-            // The ECMAScript standard chose bad variable names;
-            // I'm just being consistent :/
-            var k;
-            var len;
-            var n;
-
-            len = this.length;
-            if (len === 0) {
-                return false;
-            }
-
-            // ~~+ is a concise way to coerce things into integers.
-            n = ~~+fromIndex || 0;
-            if (n >= 0) {
-                k = n;
-            } else {
-                k = len + n;
-                if (k < 0) {
-                    k = 0;
-                }
-            }
-
-            for (/* 👆👀 */; k < len; k++) {
-                if (this[k] === searchElement) {
-                    return true;
-                }
-            }
-            return false;
-        }
+        return false;
     }
     </script>
 

--- a/index.html
+++ b/index.html
@@ -104,13 +104,13 @@
         return element.id;
     }).toArray();
 
-    navigateToPageBasedOnHash(window.location.hash);
+    navigateToPageBasedOnHash();
 
     // Whenever the URI's #fragment (a.k.a., hash) changes, navigate to a new page.
     // NB: the sidebar links will change the hash appropriately.
     if ('onhashchange' in window) {
         window.onhashchange = (_event) => {
-            navigateToPageBasedOnHash(window.location.hash);
+            navigateToPageBasedOnHash();
             // You clicked a link in the sidebar, so the sidebar should close.
             toggleSideBarOnMobile();
         }
@@ -122,7 +122,8 @@
         }
     }
 
-    function navigateToPageBasedOnHash(hash) {
+    function navigateToPageBasedOnHash() {
+        let hash = window.location.hash;
         console.assert(hash.length === 0 || hash[0] === '#');
         var requestedPage = hash.slice('1');
 

--- a/index.html
+++ b/index.html
@@ -106,11 +106,6 @@
         return element.id;
     }).toArray();
 
-    function goToPage(name) {
-        $('#page-content-wrapper').load('pages/' + name + '.html');
-        $(window).scrollTop(0);
-    }
-
 
     // this if else allows the URL's to specify what tab you want to see
     if (pages.includes(requestedPage)) {
@@ -131,6 +126,13 @@
         if ($(window).width() < 700){
             $("#wrapper").toggleClass("toggled");
         }
+    }
+
+    // Navigates to the given page name.
+    // The name must coorespond to a file in pages/*.html. 
+    function goToPage(name) {
+        $('#page-content-wrapper').load('pages/' + name + '.html');
+        $(window).scrollTop(0);
     }
     </script>
 

--- a/index.html
+++ b/index.html
@@ -95,42 +95,26 @@
 
 
     var hash = window.location.hash;
+    console.assert(hash.length === 0 || hash[0] === '#');
+    var requestedPage = hash.slice('1');
+
+    // Get a array of all of the valid pages.
+    // Valid pages are marked by an #id in the sidebar-nav.
+    var pages = $('.sidebar-nav a[id]').map(function (_index, element) {
+        return element.id;
+    }).toArray();
 
     function goToPage(name) {
         $('#page-content-wrapper').load('pages/' + name + '.html');
         $(window).scrollTop(0);
     }
 
+
     // this if else allows the URL's to specify what tab you want to see
-    if(hash == "#tutoring") {
-        goToPage('tutoring');
-    }
-    else if(hash == "#events") {
-    	goToPage('events');
-    }
-    else if(hash == "#executives") {
-        goToPage('executives');
-    }
-    else if(hash == "#resources") {
-    	goToPage('resources');
-    }
-    else if(hash == "#scholarships") {
-        goToPage('scholarships');
-    }
-    else if(hash == "#contact-us") {
-    	goToPage('contact-us');
-    }
-    else if(hash == "#sign-up") {
-    	goToPage('sign-up');
-    }
-    else if(hash == "#contact-us-on") {
-    	goToPage('contact-us-on');
-    }
-    else if(hash == "#blog") {
-        goToPage('blog');
-    }
-    else {
-    	goToPage('home');
+    if (pages.includes(requestedPage)) {
+        goToPage(requestedPage);
+    } else {
+        goToPage('home');
     }
 
 

--- a/index.html
+++ b/index.html
@@ -93,6 +93,8 @@
 
     $('#footer').load('pages/footer.html');
 
+    // Links that go to a subpage.
+    var pageLinks = $('.sidebar-nav a[id]');
 
     var hash = window.location.hash;
     console.assert(hash.length === 0 || hash[0] === '#');
@@ -100,7 +102,7 @@
 
     // Get a array of all of the valid pages.
     // Valid pages are marked by an #id in the sidebar-nav.
-    var pages = $('.sidebar-nav a[id]').map(function (_index, element) {
+    var pages = pageLinks.map(function (_index, element) {
         return element.id;
     }).toArray();
 

--- a/index.html
+++ b/index.html
@@ -110,12 +110,10 @@
 
     // Whenever the URI's #fragment (a.k.a., hash) changes, navigate to a new page.
     // NB: the sidebar links will change the hash appropriately.
-    if ('onhashchange' in window) {
-        window.onhashchange = function (_event) {
-            navigateToPageBasedOnHash();
-            // You clicked a link in the sidebar, so the sidebar should close.
-            toggleSideBarOnMobile();
-        }
+    window.onhashchange = function (_event) {
+        navigateToPageBasedOnHash();
+        // You clicked a link in the sidebar, so the sidebar should close.
+        toggleSideBarOnMobile();
     }
 
     function toggleSideBarOnMobile() {


### PR DESCRIPTION
I DRY'd up the page navigation, so all you need to do to add a new page is:

 - create the page in `pages/`
 - add a link like `<a href="#page" id="page"> Page Title </a>` in `.sidebar-nav`

Through a series of  incremental refactors, the tower of if/else-ifs is now a function called `navigateToPageBasedOnHash()`, which... navigates to the given page based on `location.hash`.

As an added bonus, navigation is invoked on the [`onhashchanged` event](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onhashchange), meaning that any link like `<a href="#page-name">` will navigate to that page (as opposed to only being in the `sidebar`).

Other things: I got rid of arrow functions [because IE11 doesn't support them](https://caniuse.com/#feat=arrow-functions) — [IE11 is used almost as often as Safari on desktop devices ](http://gs.statcounter.com/browser-market-share/desktop/canada) 😩.